### PR TITLE
User data

### DIFF
--- a/src/resources/css/style.css
+++ b/src/resources/css/style.css
@@ -67,6 +67,10 @@ form {
     backdrop-filter: blur(3px) brightness(60%);
 }
 
+.info-box a {
+    color: #174762
+}
+
 .info-box li {
     list-style-type: none;
 }

--- a/src/resources/index.html
+++ b/src/resources/index.html
@@ -185,6 +185,10 @@
             <li>y: <span class="coord-y"></span></li>
             <li>z: <span class="coord-z"></span></li>
         </ul>
+        <div class="exits">
+            <p>Exits:</p>
+            <ul></ul>
+        </div>
         <div class="special">
             <p>Special:</p>
             <ul></ul>

--- a/src/resources/index.html
+++ b/src/resources/index.html
@@ -178,7 +178,7 @@
     <div class="info-box">
         <p>Room ID: <span class="room-id"></span></p>
         <p>Name: <span class="room-name"></span></p>
-        <p>Environment ID: <span class="room-env"></span></p>
+        <p>Env ID: <span class="room-env"></span></p>
         <p>Coordinates:
         <ul>
             <li>x: <span class="coord-x"></span></li>

--- a/src/resources/index.html
+++ b/src/resources/index.html
@@ -178,6 +178,7 @@
     <div class="info-box">
         <p>Room ID: <span class="room-id"></span></p>
         <p>Name: <span class="room-name"></span></p>
+        <p>Environment ID: <span class="room-env"></span></p>
         <p>Coordinates:
         <ul>
             <li>x: <span class="coord-x"></span></li>
@@ -186,6 +187,10 @@
         </ul>
         <div class="special">
             <p>Special:</p>
+            <ul></ul>
+        </div>
+        <div class="userData">
+            <p>Other:</p>
             <ul></ul>
         </div>
     </div>

--- a/src/resources/js/map.js
+++ b/src/resources/js/map.js
@@ -579,11 +579,10 @@ class MapRenderer {
         infoBox.find(".coord-y").html(room.y);
         infoBox.find(".coord-z").html(room.z);
 
-        this.infoExitsGroup(infoBox.find(".exits"), room.exits)
-        this.infoExitsGroup(infoBox.find(".special"), room.specialExits)
+        this.infoExitsGroup(infoBox.find(".exits"), room.exits);
+        this.infoExitsGroup(infoBox.find(".special"), room.specialExits);
 
-        this.userDataGroup(infoBox.find(".userData"), room.userData)
-
+        this.userDataGroup(infoBox.find(".userData"), room.userData);
     }
 
     userDataGroup(container, userData) {
@@ -1198,6 +1197,8 @@ jQuery(function () {
         highlights = toHighlight.split(",")
     }
     let controls = new Controls(canvas, mapData);
+    globalControls = controls;
+    globalControls.lightMode = true
     let roomSearch = params.get('id');
     if (!roomSearch) {
         controls.draw(area, 0, highlights);

--- a/src/resources/js/map.js
+++ b/src/resources/js/map.js
@@ -572,6 +572,7 @@ class MapRenderer {
         infoBox.toggle(true);
         infoBox.find(".room-id").html(room.id);
         infoBox.find(".room-name").html(room.name);
+        infoBox.find(".room-env").html(room.env);
         infoBox.find(".coord-x").html(room.x);
         infoBox.find(".coord-y").html(room.y);
         infoBox.find(".coord-z").html(room.z);
@@ -585,6 +586,15 @@ class MapRenderer {
             specialList.append("<li>" + exit + " : " + room.specialExits[exit] + "</li>")
         }
         special.toggle(show)
+        let userData = infoBox.find(".userData");
+        let userDataList = userData.find("ul");
+        userDataList.html("");
+        let UDshow = false;
+        for (let userDataKey in room.userData) {
+            UDshow = true;
+            userDataList.append("<li>" + userDataKey + ":<br>&nbsp; &nbsp; &nbsp;" + room.userData[userDataKey] + "</lu>")
+        }
+        userData.toggle(UDshow)
     }
 
     hideRoomInfo() {

--- a/src/scripts/MapExplorer/map-exporter.lua
+++ b/src/scripts/MapExplorer/map-exporter.lua
@@ -29,6 +29,11 @@ function MapExporter:export()
         }
         for k, v in pairs(rooms) do
             local x,y,z = getRoomCoordinates(v)
+            local userDataKeys = getRoomUserDataKeys(v)
+            local userData = {}
+            for _,key in ipairs(userDataKeys) do
+              userData[key] = getRoomUserData(v,key)
+            end
             local roomInfo = {
                 id = v,
                 x = x,
@@ -41,7 +46,8 @@ function MapExporter:export()
                 doors = getDoors(v),
                 customLines = self:fixCustomLines(getCustomLines(v)),
                 specialExits = getSpecialExitsSwap(v),
-                stubs = getExitStubs1(v)
+                stubs = getExitStubs1(v),
+                userData = table.size(userData) > 0 and userData or nil
             }
             table.insert(areaRooms.rooms, roomInfo)
         end
@@ -59,14 +65,29 @@ function MapExporter:export()
     file:close()
 
     local colors = {}
-    for k,v in pairs(getCustomEnvColorTable()) do
-        local singleColor = {
-            envId = k,
-            colors = v
-        }
-        table.insert(colors, singleColor)
+    local adjustedColors = {}
+    for i=0,255 do
+        if i ~= 16 then -- ansi 016 is ignored.
+            local key = string.format("ansi_%03d",i)
+            local envID
+            if i == 0 or i == 8 then -- ansi 000 is set to envID 8, and ansi 008 is set to envID 16, due to envID starting at 1 and ansi colors at 0
+                envID = i + 8
+            else
+                envID = i
+            end
+            colors[envID] = color_table[key]
+        end
     end
-
+    for k,v in pairs(getCustomEnvColorTable()) do
+        colors[k] = v
+    end
+    for envID,color in pairs(colors) do
+      table.insert(adjustedColors, {
+        envId = envID,
+        colors = color
+      })
+    end
+    colors = adjustedColors
 
     local colorsFileName = self.dir .. "data/colors.js"
     colorsFile = io.open (colorsFileName, "w+")
@@ -86,7 +107,10 @@ function MapExporter:export()
         currentPosition:close()
     end
 
-    openUrl("file:///" .. self.dir .. "index.html")
+    local fileLocation = self.dir .. "index.html"
+    local fileURL = "file:///" .. fileLocation
+    cecho("<white:blue>Map Explorer:<red> Opening map explorer page at " .. fileLocation .. "\n")
+    openUrl(fileURL)
 end
 
 function MapExporter:fixCustomLines(lineObj)

--- a/src/scripts/MapExplorer/map-exporter.lua
+++ b/src/scripts/MapExplorer/map-exporter.lua
@@ -32,7 +32,7 @@ function MapExporter:export()
             local userDataKeys = getRoomUserDataKeys(v)
             local userData = {}
             for _,key in ipairs(userDataKeys) do
-              userData[key] = getRoomUserData(v,key)
+                userData[key] = getRoomUserData(v,key)
             end
             local roomInfo = {
                 id = v,
@@ -109,7 +109,7 @@ function MapExporter:export()
 
     local fileLocation = self.dir .. "index.html"
     local fileURL = "file:///" .. fileLocation
-    cecho("<white:blue>Map Explorer:<red> Opening map explorer page at " .. fileLocation .. "\n")
+    cecho("<white:blue>Map Explorer:<red:black> Opening map explorer page at " .. fileLocation .. "\n")
     openUrl(fileURL)
 end
 


### PR DESCRIPTION
Adds user data display to the info box. Also adds Env ID to the info box.

Captures the bog standard default mudlet environment colors for environments 1-255, before then overlaying that with the information from getCustomEnvColorTable().

This should make maps made from scratch in Mudlet look how they do in Mudlet.
Apparently though there is secret environment color data hidden away somewhere in the mapper which can be included in the XML file which is provided by certain MUDs (IRE in particular I know does this). This means that my starmoun map looks pretty different in the browser than it does in Mudlet.

Mudlet:
![image](https://user-images.githubusercontent.com/3660/85236501-8730d680-b3ec-11ea-96ba-bd12b33c4c65.png)

Web map:
![image](https://user-images.githubusercontent.com/3660/85236512-9748b600-b3ec-11ea-93d8-0e755c1c3966.png)
