### PR TITLE
added roomHashes to export/search

### DIFF
--- a/src/resources/index.html
+++ b/src/resources/index.html
@@ -188,6 +188,7 @@
   <div class="map-container">
     <div class="info-box">
       <p>Room ID: <span class="room-id"></span></p>
+      <p>Room Hash: <span class="room-hash"></span></p>
       <p>Name: <span class="room-name"></span></p>
       <p>Env ID: <span class="room-env"></span></p>
       <p>Coordinates:

--- a/src/resources/js/map.js
+++ b/src/resources/js/map.js
@@ -33,11 +33,15 @@ mapData.sort(function (areaElement1, areaElement2) {
 
 let mapDataIndex = {};
 let roomIndex = {};
+let roomHash = {};
 mapData.forEach(function (value, index) {
   mapDataIndex[value.areaId] = index;
   value.rooms.forEach(room => {
     room.areaId = value.areaId;
     roomIndex[room.id] = room;
+    if (room.userData) {
+      roomHash[room.userData.hash] = room.id;
+    }
   });
 });
 
@@ -560,6 +564,7 @@ class MapRenderer {
     let infoBox = jQuery(".info-box");
     infoBox.toggle(true);
     infoBox.find(".room-id").html(room.id);
+    infoBox.find(".room-hash").html(room.userData.hash);
     infoBox.find(".room-name").html(room.name);
     infoBox.find(".room-env").html(room.env);
     infoBox.find(".coord-x").html(room.x);
@@ -1204,11 +1209,14 @@ jQuery(function () {
   
   let controls = new Controls(canvas, mapData);
   let roomSearch = params.get('id');
-  if (!roomSearch) {
+  let hashSearch = params.get('hash');
+  if (roomSearch) {
+    controls.findRoom(parseInt(roomSearch));
+  } else if (hashSearch) {
+    controls.findRoom( parseInt( roomHash[hashSearch] ) );
+  } else {
     controls.draw(area, 0);
     controls.zoom(settings.defaultZoom);
-  } else {
-    controls.findRoom(parseInt(roomSearch));
   }
   
   

--- a/src/scripts/MapExplorer/map-exporter.lua
+++ b/src/scripts/MapExplorer/map-exporter.lua
@@ -24,7 +24,7 @@ function MapExporter:getRoomInfo(roomId)
   for _,key in ipairs(userDataKeys) do
     userData[key] = getRoomUserData(roomId,key)
   end
-  userData.hash = roomId
+  userData.hash = getRoomHashByID(roomId)
   local roomInfo = {
     id = roomId,
     x = x,

--- a/src/scripts/MapExplorer/map-exporter.lua
+++ b/src/scripts/MapExplorer/map-exporter.lua
@@ -24,6 +24,7 @@ function MapExporter:getRoomInfo(roomId)
   for _,key in ipairs(userDataKeys) do
     userData[key] = getRoomUserData(roomId,key)
   end
+  userData.hash = roomId
   local roomInfo = {
     id = roomId,
     x = x,


### PR DESCRIPTION
Our mud relies on room hashes which makes linking to a room difficult as the ID is generated in mudlet, Added hash to the export json, along with an hash index so that it can be searched by ?hash=abc.123 from the url, and finally added Room Hash: under room ID: in the index.html popup room info modal.